### PR TITLE
Persist artwork URLs across web reloads via localStorage

### DIFF
--- a/frontend/composeApp/src/androidMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistenceFactory.android.kt
+++ b/frontend/composeApp/src/androidMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistenceFactory.android.kt
@@ -1,0 +1,8 @@
+package com.ifochka.m14n.data.artwork
+
+import com.ifochka.m14n.data.db.ChartDatabaseRepository
+
+actual fun createArtworkUrlPersistence(database: ChartDatabaseRepository): ArtworkUrlPersistence {
+    println("[ARTWORK-PERSISTENCE-FACTORY] Creating SqlDelightArtworkUrlPersistence for Android")
+    return SqlDelightArtworkUrlPersistence(database)
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistence.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistence.kt
@@ -1,0 +1,10 @@
+package com.ifochka.m14n.data.artwork
+
+interface ArtworkUrlPersistence {
+    suspend fun getArtworkUrl(trackId: Long): String?
+
+    suspend fun saveArtworkUrl(
+        trackId: Long,
+        url: String,
+    )
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistenceFactory.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistenceFactory.kt
@@ -1,0 +1,5 @@
+package com.ifochka.m14n.data.artwork
+
+import com.ifochka.m14n.data.db.ChartDatabaseRepository
+
+expect fun createArtworkUrlPersistence(database: ChartDatabaseRepository): ArtworkUrlPersistence

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/artwork/CachedArtworkRepository.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/artwork/CachedArtworkRepository.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.sync.withLock
  */
 class CachedArtworkRepository(
     private val artworkApi: ArtworkApi,
+    private val persistence: ArtworkUrlPersistence,
     private val requestDelayMs: Long = 1000L,
 ) : ArtworkRepository {
     private val rateLimitMutex = Mutex()
@@ -21,11 +22,23 @@ class CachedArtworkRepository(
     override suspend fun getArtworkUrl(track: Track): String? {
         println("[ARTWORK-REPO] 🔍 getArtworkUrl called for: ${track.artistName} - ${track.title}")
 
-        // Check in-memory cache first
+        // Check in-memory cache first (populated by DB JOIN on native platforms)
         val cachedUrl = track.artworkUrl?.takeIf { it.isNotBlank() }
         if (cachedUrl != null) {
             println("[ARTWORK-REPO] ⊘ Track already has artwork: $cachedUrl")
             return cachedUrl
+        }
+
+        return fetchWithPersistence(track)
+    }
+
+    private suspend fun fetchWithPersistence(track: Track): String? {
+        val trackId = track.id
+
+        // Check persistent storage (localStorage on web, SQLite on native)
+        if (trackId != null) {
+            val persistedUrl = persistence.getArtworkUrl(trackId)
+            if (persistedUrl != null) return persistedUrl
         }
 
         // Extract and validate required fields
@@ -37,6 +50,11 @@ class CachedArtworkRepository(
                 null
             }
             else -> fetchArtworkFromApi(artistName, trackTitle)
+        }
+
+        // Persist the fetched URL for future loads
+        if (result != null && trackId != null) {
+            persistence.saveArtworkUrl(trackId = trackId, url = result)
         }
 
         return result

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/artwork/SqlDelightArtworkUrlPersistence.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/artwork/SqlDelightArtworkUrlPersistence.kt
@@ -1,0 +1,25 @@
+package com.ifochka.m14n.data.artwork
+
+import com.ifochka.m14n.data.db.ChartDatabaseRepository
+
+class SqlDelightArtworkUrlPersistence(
+    private val database: ChartDatabaseRepository,
+) : ArtworkUrlPersistence {
+    override suspend fun getArtworkUrl(trackId: Long): String? {
+        val url = database.getArtworkUrl(trackId)
+        if (url != null) {
+            println("[ARTWORK-PERSISTENCE] ✓ Hit SQLite for track $trackId: $url")
+        } else {
+            println("[ARTWORK-PERSISTENCE] ✗ Miss for track $trackId — calling iTunes API")
+        }
+        return url
+    }
+
+    override suspend fun saveArtworkUrl(
+        trackId: Long,
+        url: String,
+    ) {
+        database.updateTrackArtwork(trackId = trackId, artworkUrl = url)
+        println("[ARTWORK-PERSISTENCE] ✓ Saved to SQLite for track $trackId")
+    }
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/db/ChartDatabaseRepository.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/db/ChartDatabaseRepository.kt
@@ -32,6 +32,8 @@ interface ChartDatabaseRepository {
         weekDate: String,
     ): Long?
 
+    suspend fun getArtworkUrl(trackId: Long): String?
+
     suspend fun updateTrackArtwork(
         trackId: Long,
         artworkUrl: String,
@@ -260,6 +262,9 @@ class SqlDelightChartDatabase(
         return database.chartQueries.selectChartListByChartAndWeek(chartId, week.id)
             .awaitAsOneOrNull()?.cached_at
     }
+
+    override suspend fun getArtworkUrl(trackId: Long): String? =
+        database.chartQueries.selectArtworkUrlByTrackId(trackId).awaitAsOneOrNull()
 
     override suspend fun updateTrackArtwork(
         trackId: Long,

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/repository/CachedChartRepository.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/repository/CachedChartRepository.kt
@@ -84,13 +84,8 @@ class CachedChartRepository(
     }
 
     /**
-     * Fetch artwork URL for a single track and persist it to the database.
-     * Called on-demand when the track becomes visible in the UI.
+     * Fetch artwork URL for a single track.
+     * Persistence is handled by ArtworkRepository via ArtworkUrlPersistence.
      */
-    suspend fun getArtworkUrl(track: Track): String? =
-        track.id?.let { trackId ->
-            artworkRepository.getArtworkUrl(track)?.also { artworkUrl ->
-                database.updateTrackArtwork(trackId = trackId, artworkUrl = artworkUrl)
-            }
-        }
+    suspend fun getArtworkUrl(track: Track): String? = artworkRepository.getArtworkUrl(track)
 }

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/di/AppModule.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/di/AppModule.kt
@@ -5,8 +5,10 @@ import com.ifochka.m14n.data.api.KtorM14nApi
 import com.ifochka.m14n.data.api.M14nApi
 import com.ifochka.m14n.data.artwork.ArtworkApi
 import com.ifochka.m14n.data.artwork.ArtworkRepository
+import com.ifochka.m14n.data.artwork.ArtworkUrlPersistence
 import com.ifochka.m14n.data.artwork.CachedArtworkRepository
 import com.ifochka.m14n.data.artwork.createArtworkApi
+import com.ifochka.m14n.data.artwork.createArtworkUrlPersistence
 import com.ifochka.m14n.data.db.ChartDatabaseRepository
 import com.ifochka.m14n.data.db.SqlDelightChartDatabase
 import com.ifochka.m14n.data.db.createDatabaseDriver
@@ -53,7 +55,8 @@ val appModule = module {
 
     // Artwork dependencies (platform-specific: JVM uses HTTP, wasmJs uses JSONP)
     single<ArtworkApi> { createArtworkApi(get()) }
-    single<ArtworkRepository> { CachedArtworkRepository(get()) }
+    single<ArtworkUrlPersistence> { createArtworkUrlPersistence(get()) }
+    single<ArtworkRepository> { CachedArtworkRepository(artworkApi = get(), persistence = get()) }
 
     // Share (platform-specific: Android has native share sheet)
     single<ShareManager> { createShareManager() }

--- a/frontend/composeApp/src/commonMain/sqldelight/com/ifochka/m14n/db/Chart.sq
+++ b/frontend/composeApp/src/commonMain/sqldelight/com/ifochka/m14n/db/Chart.sq
@@ -211,6 +211,12 @@ LEFT JOIN artwork aw ON ta.artwork_id = aw.id
 WHERE ct.chart_list_id = ?
 ORDER BY ct.rank;
 
+selectArtworkUrlByTrackId:
+SELECT aw.url
+FROM track_artwork ta
+JOIN artwork aw ON ta.artwork_id = aw.id
+WHERE ta.track_id = ?;
+
 insertChartTrack:
 INSERT OR REPLACE INTO chart_track (chart_list_id, track_id, rank, last_week_rank)
 VALUES (?, ?, ?, ?);

--- a/frontend/composeApp/src/jvmMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistenceFactory.jvm.kt
+++ b/frontend/composeApp/src/jvmMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistenceFactory.jvm.kt
@@ -1,0 +1,8 @@
+package com.ifochka.m14n.data.artwork
+
+import com.ifochka.m14n.data.db.ChartDatabaseRepository
+
+actual fun createArtworkUrlPersistence(database: ChartDatabaseRepository): ArtworkUrlPersistence {
+    println("[ARTWORK-PERSISTENCE-FACTORY] Creating SqlDelightArtworkUrlPersistence for JVM")
+    return SqlDelightArtworkUrlPersistence(database)
+}

--- a/frontend/composeApp/src/wasmJsMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistenceFactory.wasmJs.kt
+++ b/frontend/composeApp/src/wasmJsMain/kotlin/com/ifochka/m14n/data/artwork/ArtworkUrlPersistenceFactory.wasmJs.kt
@@ -1,0 +1,8 @@
+package com.ifochka.m14n.data.artwork
+
+import com.ifochka.m14n.data.db.ChartDatabaseRepository
+
+actual fun createArtworkUrlPersistence(database: ChartDatabaseRepository): ArtworkUrlPersistence {
+    println("[ARTWORK-PERSISTENCE-FACTORY] Creating LocalStorageArtworkUrlPersistence for wasmJs")
+    return LocalStorageArtworkUrlPersistence()
+}

--- a/frontend/composeApp/src/wasmJsMain/kotlin/com/ifochka/m14n/data/artwork/LocalStorageArtworkUrlPersistence.kt
+++ b/frontend/composeApp/src/wasmJsMain/kotlin/com/ifochka/m14n/data/artwork/LocalStorageArtworkUrlPersistence.kt
@@ -1,0 +1,28 @@
+package com.ifochka.m14n.data.artwork
+
+private external fun jsLocalStorageGet(key: String): String?
+
+private external fun jsLocalStorageSet(
+    key: String,
+    value: String,
+)
+
+class LocalStorageArtworkUrlPersistence : ArtworkUrlPersistence {
+    override suspend fun getArtworkUrl(trackId: Long): String? {
+        val url = jsLocalStorageGet("artwork_track_$trackId")
+        if (url != null) {
+            println("[ARTWORK-PERSISTENCE] ✓ Hit localStorage for track $trackId: $url")
+        } else {
+            println("[ARTWORK-PERSISTENCE] ✗ Miss for track $trackId — calling iTunes API")
+        }
+        return url
+    }
+
+    override suspend fun saveArtworkUrl(
+        trackId: Long,
+        url: String,
+    ) {
+        jsLocalStorageSet("artwork_track_$trackId", url)
+        println("[ARTWORK-PERSISTENCE] ✓ Saved to localStorage for track $trackId")
+    }
+}

--- a/frontend/composeApp/src/wasmJsMain/resources/index.html
+++ b/frontend/composeApp/src/wasmJsMain/resources/index.html
@@ -83,6 +83,19 @@
         console.log('[iTunes Bridge] Static dispatcher initialized');
     </script>
 
+    <!-- localStorage Bridge for Artwork Persistence -->
+    <script>
+        function jsLocalStorageGet(key) {
+            return localStorage.getItem(key);
+        }
+
+        function jsLocalStorageSet(key, value) {
+            localStorage.setItem(key, value);
+        }
+
+        console.log('[localStorage Bridge] Initialized');
+    </script>
+
     <script src="composeApp.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Artwork images were re-fetched from iTunes on every web page reload because WasmJS uses an in-memory SQLite that resets on reload
- Introduces `ArtworkUrlPersistence` abstraction: `localStorage` on web, SQLite on native (JVM/Android)
- Moves persistence ownership from `CachedChartRepository` into `CachedArtworkRepository` (correct layering)

## How it works

**Web (wasmJs):** `LocalStorageArtworkUrlPersistence` stores artwork URLs under keys `artwork_track_<id>` in `localStorage`. Survives page reloads. ~10KB for a full chart — well within the 5–10MB browser limit.

**Native (JVM/Android):** `SqlDelightArtworkUrlPersistence` reads/writes via the existing `artwork + track_artwork` SQLite tables. No schema changes.

**Flow in `CachedArtworkRepository.getArtworkUrl()`:**
1. Check `track.artworkUrl` (in-memory, from DB JOIN on native)
2. Check `ArtworkUrlPersistence.get(trackId)` ← new
3. Call iTunes API
4. `ArtworkUrlPersistence.save(trackId, url)` ← new

## Test plan

- [ ] Open web app → console shows `[ARTWORK-REPO] 📡 Calling iTunes API` for each track
- [ ] DevTools → Application → Local Storage → confirm `artwork_track_<id>` keys appear
- [ ] Reload page → console shows `[ARTWORK-PERSISTENCE] ✓ Hit localStorage` — no iTunes calls
- [ ] Artwork appears instantly on reload (no cascade delay)
- [ ] On JVM/Android: `[ARTWORK-PERSISTENCE] ✓ Hit SQLite` on second launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)