### PR TITLE
UI: adaptive layout — PermanentNavigationDrawer on wide screens

### DIFF
--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/App.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/App.kt
@@ -1,6 +1,9 @@
 package com.ifochka.m14n
 
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
@@ -10,13 +13,20 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.PermanentDrawerSheet
+import androidx.compose.material3.PermanentNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
 import com.ifochka.m14n.navigation.Navigator
@@ -32,6 +42,12 @@ import com.ifochka.m14n.ui.home.HomeScreen
 import com.ifochka.m14n.ui.search.SearchScreen
 import com.ifochka.m14n.ui.theme.M14nTheme
 
+private data class NavItem(
+    val route: NavKey,
+    val icon: ImageVector,
+    val label: String,
+)
+
 @Composable
 @Preview
 fun App() {
@@ -46,59 +62,72 @@ fun App() {
             )
             val navigator = remember { Navigator(navigationState) }
 
-            Scaffold(
-                modifier = Modifier.fillMaxSize(),
-                bottomBar = {
-                    NavigationBar {
-                        NavigationBarItem(
-                            selected = navigationState.topLevelRoute == RouteHome,
-                            onClick = { navigator.navigate(RouteHome) },
-                            icon = { Icon(imageVector = Icons.Default.Home, contentDescription = "Home") },
-                            label = { Text("Home") },
-                        )
-                        NavigationBarItem(
-                            selected = navigationState.topLevelRoute == RouteBestSongs,
-                            onClick = { navigator.navigate(RouteBestSongs) },
-                            icon = { Icon(imageVector = Icons.Default.Star, contentDescription = "Best Songs") },
-                            label = { Text("Best") },
-                        )
-                        NavigationBarItem(
-                            selected = navigationState.topLevelRoute == RouteHistory,
-                            onClick = { navigator.navigate(RouteHistory) },
-                            icon = { Icon(imageVector = Icons.Default.BarChart, contentDescription = "History") },
-                            label = { Text("History") },
-                        )
-                        NavigationBarItem(
-                            selected = navigationState.topLevelRoute == RouteSearch,
-                            onClick = { navigator.navigate(RouteSearch) },
-                            icon = { Icon(imageVector = Icons.Default.Search, contentDescription = "Search") },
-                            label = { Text("Search") },
-                        )
-                    }
-                },
-            ) { paddingValues ->
-                NavDisplay(
-                    entries = navigationState.toEntries(
-                        remember {
-                            entryProvider {
-                                entry<RouteHome> {
-                                    HomeScreen()
-                                }
-                                entry<RouteBestSongs> {
-                                    BestSongsScreen()
-                                }
-                                entry<RouteHistory> {
-                                    ChartScreen()
-                                }
-                                entry<RouteSearch> {
-                                    SearchScreen()
+            val navItems = remember {
+                listOf(
+                    NavItem(RouteHome, Icons.Default.Home, "Home"),
+                    NavItem(RouteBestSongs, Icons.Default.Star, "Best"),
+                    NavItem(RouteHistory, Icons.Default.BarChart, "History"),
+                    NavItem(RouteSearch, Icons.Default.Search, "Search"),
+                )
+            }
+
+            val provider: (NavKey) -> NavEntry<NavKey> = remember {
+                entryProvider {
+                    entry<RouteHome> { HomeScreen() }
+                    entry<RouteBestSongs> { BestSongsScreen() }
+                    entry<RouteHistory> { ChartScreen() }
+                    entry<RouteSearch> { SearchScreen() }
+                }
+            }
+
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                val isWide = maxWidth >= 840.dp
+                if (isWide) {
+                    PermanentNavigationDrawer(
+                        drawerContent = {
+                            PermanentDrawerSheet {
+                                Spacer(modifier = Modifier.height(12.dp))
+                                navItems.forEach { item ->
+                                    NavigationDrawerItem(
+                                        icon = { Icon(item.icon, contentDescription = item.label) },
+                                        label = { Text(item.label) },
+                                        selected = navigationState.topLevelRoute == item.route,
+                                        onClick = { navigator.navigate(item.route) },
+                                        modifier = Modifier.padding(horizontal = 8.dp),
+                                    )
                                 }
                             }
                         },
-                    ),
-                    onBack = { navigator.goBack() },
-                    modifier = Modifier.padding(paddingValues),
-                )
+                    ) {
+                        NavDisplay(
+                            entries = navigationState.toEntries(provider),
+                            onBack = { navigator.goBack() },
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                } else {
+                    Scaffold(
+                        modifier = Modifier.fillMaxSize(),
+                        bottomBar = {
+                            NavigationBar {
+                                navItems.forEach { item ->
+                                    NavigationBarItem(
+                                        selected = navigationState.topLevelRoute == item.route,
+                                        onClick = { navigator.navigate(item.route) },
+                                        icon = { Icon(item.icon, contentDescription = item.label) },
+                                        label = { Text(item.label) },
+                                    )
+                                }
+                            }
+                        },
+                    ) { paddingValues ->
+                        NavDisplay(
+                            entries = navigationState.toEntries(provider),
+                            onBack = { navigator.goBack() },
+                            modifier = Modifier.padding(paddingValues),
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wraps `App.kt` layout in `BoxWithConstraints` and branches on `maxWidth >= 840.dp`
- Wide screens (≥840dp): `PermanentNavigationDrawer` on the left, content fills remaining space
- Compact screens (<840dp): existing `Scaffold` + `NavigationBar` at the bottom, unchanged
- Extracts `NavItem` data class and shared `entryProvider` to eliminate duplication

## Test plan
- [ ] Widen browser window past 840dp → permanent drawer appears on left, bottom bar gone
- [ ] Narrow below 840dp → bottom bar reappears, drawer gone
- [ ] All 4 nav items (Home, Best, History, Search) work in both layouts
- [ ] Selection highlight updates correctly when navigating

🤖 Generated with [Claude Code](https://claude.com/claude-code)