### PR TITLE
UI: ArtistDetailsScreen — profile, top tracks, collaborators (#70)

### DIFF
--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/App.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/App.kt
@@ -36,6 +36,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
 import com.ifochka.m14n.navigation.ListDetailScene
 import com.ifochka.m14n.navigation.Navigator
+import com.ifochka.m14n.navigation.RouteArtistDetails
 import com.ifochka.m14n.navigation.RouteBestSongs
 import com.ifochka.m14n.navigation.RouteHistory
 import com.ifochka.m14n.navigation.RouteHome
@@ -44,6 +45,7 @@ import com.ifochka.m14n.navigation.RouteTrackDetails
 import com.ifochka.m14n.navigation.rememberListDetailSceneStrategy
 import com.ifochka.m14n.navigation.rememberNavigationState
 import com.ifochka.m14n.navigation.toEntries
+import com.ifochka.m14n.ui.artistdetails.ArtistDetailsScreen
 import com.ifochka.m14n.ui.bestsongs.BestSongsScreen
 import com.ifochka.m14n.ui.chart.ChartScreen
 import com.ifochka.m14n.ui.home.HomeScreen
@@ -94,12 +96,24 @@ fun App() {
                         ChartScreen(onTrackClick = { id -> navigator.navigate(RouteTrackDetails(id)) })
                     }
                     entry<RouteSearch>(metadata = ListDetailScene.listPane()) {
-                        SearchScreen(onTrackClick = { id -> navigator.navigate(RouteTrackDetails(id)) })
+                        SearchScreen(
+                            onTrackClick = { id -> navigator.navigate(RouteTrackDetails(id)) },
+                            onArtistClick = { id -> navigator.navigate(RouteArtistDetails(id)) },
+                        )
                     }
                     entry<RouteTrackDetails>(metadata = ListDetailScene.detailPane()) { route ->
                         TrackDetailsScreen(
                             viewModel = koinViewModel(parameters = { parametersOf(route.trackId) }),
                             onBack = { navigator.goBack() },
+                            onArtistClick = { id -> navigator.navigate(RouteArtistDetails(id)) },
+                        )
+                    }
+                    entry<RouteArtistDetails>(metadata = ListDetailScene.detailPane()) { route ->
+                        ArtistDetailsScreen(
+                            viewModel = koinViewModel(parameters = { parametersOf(route.artistId) }),
+                            onBack = { navigator.goBack() },
+                            onTrackClick = { id -> navigator.navigate(RouteTrackDetails(id)) },
+                            onArtistClick = { id -> navigator.navigate(RouteArtistDetails(id)) },
                         )
                     }
                 }

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/api/KtorM14nApi.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/api/KtorM14nApi.kt
@@ -1,5 +1,6 @@
 package com.ifochka.m14n.data.api
 
+import com.ifochka.m14n.data.model.ArtistInfo
 import com.ifochka.m14n.data.model.Chart
 import com.ifochka.m14n.data.model.ChartList
 import com.ifochka.m14n.data.model.DayTrack
@@ -11,6 +12,9 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+
+private const val ARTIST_RELATIONS_SIZE = 10
+private const val ARTIST_TRACKS_SIZE = 5
 
 class KtorM14nApi(
     private val httpClient: HttpClient,
@@ -84,6 +88,15 @@ class KtorM14nApi(
         runCatching {
             httpClient.get("/track/info") {
                 parameter("id", trackId)
+            }.body()
+        }
+
+    override suspend fun getArtistInfo(artistId: Long): Result<ArtistInfo> =
+        runCatching {
+            httpClient.get("/artist/info") {
+                parameter("id", artistId)
+                parameter("relations_size", ARTIST_RELATIONS_SIZE)
+                parameter("tracks_size", ARTIST_TRACKS_SIZE)
             }.body()
         }
 }

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/api/M14nApi.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/api/M14nApi.kt
@@ -1,5 +1,6 @@
 package com.ifochka.m14n.data.api
 
+import com.ifochka.m14n.data.model.ArtistInfo
 import com.ifochka.m14n.data.model.Chart
 import com.ifochka.m14n.data.model.ChartList
 import com.ifochka.m14n.data.model.DayTrack
@@ -36,4 +37,6 @@ interface M14nApi {
     suspend fun getTrackById(trackId: Long): Result<Track>
 
     suspend fun getTrackInfo(trackId: Long): Result<TrackInfo>
+
+    suspend fun getArtistInfo(artistId: Long): Result<ArtistInfo>
 }

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/model/ArtistInfo.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/data/model/ArtistInfo.kt
@@ -1,0 +1,11 @@
+package com.ifochka.m14n.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ArtistInfo(
+    val artist: Artist,
+    val globalRank: Long = 0,
+    val artistRelations: List<Artist>? = null,
+    val tracks: List<Track>? = null,
+)

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/di/AppModule.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/di/AppModule.kt
@@ -18,6 +18,7 @@ import com.ifochka.m14n.data.repository.NetworkChartRepository
 import com.ifochka.m14n.db.M14nDatabase
 import com.ifochka.m14n.share.ShareManager
 import com.ifochka.m14n.share.createShareManager
+import com.ifochka.m14n.ui.artistdetails.ArtistDetailsViewModel
 import com.ifochka.m14n.ui.bestsongs.BestSongsViewModel
 import com.ifochka.m14n.ui.chart.ChartViewModel
 import com.ifochka.m14n.ui.home.HomeViewModel
@@ -76,4 +77,5 @@ val appModule = module {
     factoryOf(::HomeViewModel)
     factoryOf(::SearchViewModel)
     factory { params -> TrackDetailsViewModel(get(), get(), params.get<Long>()) }
+    factory { params -> ArtistDetailsViewModel(get(), get(), params.get<Long>()) }
 }

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/navigation/Routes.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/navigation/Routes.kt
@@ -24,6 +24,11 @@ data class RouteTrackDetails(
     val trackId: Long,
 ) : NavKey
 
+@Serializable
+data class RouteArtistDetails(
+    val artistId: Long,
+) : NavKey
+
 val navSavedStateConfig = SavedStateConfiguration {
     serializersModule = SerializersModule {
         polymorphic(NavKey::class) {
@@ -32,6 +37,7 @@ val navSavedStateConfig = SavedStateConfiguration {
             subclass(RouteBestSongs::class, RouteBestSongs.serializer())
             subclass(RouteSearch::class, RouteSearch.serializer())
             subclass(RouteTrackDetails::class, RouteTrackDetails.serializer())
+            subclass(RouteArtistDetails::class, RouteArtistDetails.serializer())
         }
     }
 }

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/artistdetails/ArtistDetailsScreen.kt
@@ -1,0 +1,225 @@
+package com.ifochka.m14n.ui.artistdetails
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.ifochka.m14n.data.model.ChartTrack
+import com.ifochka.m14n.data.model.Track
+import com.ifochka.m14n.ui.chart.components.ChartTrackItem
+import com.ifochka.m14n.ui.chart.components.PositionBadge
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArtistDetailsScreen(
+    viewModel: ArtistDetailsViewModel,
+    onBack: () -> Unit,
+    onTrackClick: (Long) -> Unit = {},
+    onArtistClick: (Long) -> Unit = {},
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val title = (uiState as? ArtistDetailsUiState.Success)?.artist?.name ?: ""
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (val state = uiState) {
+            is ArtistDetailsUiState.Loading -> Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) { CircularProgressIndicator() }
+
+            is ArtistDetailsUiState.Error -> Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) { Text(text = state.message, color = MaterialTheme.colorScheme.error) }
+
+            is ArtistDetailsUiState.Success -> ArtistDetailsContent(
+                state = state,
+                onTrackClick = onTrackClick,
+                onArtistClick = onArtistClick,
+                onArtworkNeeded = viewModel::loadArtworkForTrack,
+                modifier = Modifier.padding(padding),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ArtistDetailsContent(
+    state: ArtistDetailsUiState.Success,
+    onTrackClick: (Long) -> Unit,
+    onArtistClick: (Long) -> Unit,
+    onArtworkNeeded: suspend (Track) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        item {
+            ArtistHero(
+                artistName = state.artist.name ?: "",
+                globalRank = state.globalRank,
+                artworkUrl = state.artworkUrl,
+            )
+        }
+        item {
+            Text(
+                text = "Top Tracks",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        itemsIndexed(state.tracks.take(5)) { index, track ->
+            ChartTrackItem(
+                chartTrack = ChartTrack(track = track, rank = index + 1),
+                badge = PositionBadge.None,
+                onArtworkNeeded = onArtworkNeeded,
+                onClick = { track.id?.let(onTrackClick) },
+                onLongPress = {},
+                onShare = null,
+            )
+        }
+        item {
+            Text(
+                text = "Collaborates with",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        item {
+            if (state.relations.isEmpty()) {
+                Text(
+                    text = "No collaborations found",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            } else {
+                FlowRow(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    state.relations.forEach { artist ->
+                        SuggestionChip(
+                            onClick = { artist.id?.let(onArtistClick) },
+                            label = { Text(artist.name ?: "") },
+                            modifier = Modifier.padding(end = 8.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtistHero(
+    artistName: String,
+    globalRank: Long,
+    artworkUrl: String?,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(16f / 9f)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+    ) {
+        if (!artworkUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = artworkUrl,
+                contentDescription = artistName,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Default.MusicNote,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(64.dp)
+                    .align(Alignment.Center),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .background(
+                    Brush.verticalGradient(
+                        listOf(Color.Transparent, Color.Black.copy(alpha = 0.72f)),
+                    ),
+                )
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+        ) {
+            Column {
+                Text(
+                    text = artistName,
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (globalRank > 0) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Text(
+                            text = " Global Rank #$globalRank",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White.copy(alpha = 0.9f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/artistdetails/ArtistDetailsUiState.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/artistdetails/ArtistDetailsUiState.kt
@@ -1,0 +1,20 @@
+package com.ifochka.m14n.ui.artistdetails
+
+import com.ifochka.m14n.data.model.Artist
+import com.ifochka.m14n.data.model.Track
+
+sealed interface ArtistDetailsUiState {
+    data object Loading : ArtistDetailsUiState
+
+    data class Success(
+        val artist: Artist,
+        val globalRank: Long,
+        val tracks: List<Track>,
+        val relations: List<Artist>,
+        val artworkUrl: String? = null,
+    ) : ArtistDetailsUiState
+
+    data class Error(
+        val message: String,
+    ) : ArtistDetailsUiState
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/artistdetails/ArtistDetailsViewModel.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/artistdetails/ArtistDetailsViewModel.kt
@@ -1,0 +1,59 @@
+package com.ifochka.m14n.ui.artistdetails
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ifochka.m14n.data.api.M14nApi
+import com.ifochka.m14n.data.artwork.ArtworkRepository
+import com.ifochka.m14n.data.model.Track
+import com.ifochka.m14n.ui.artistdetails.ArtistDetailsUiState.Loading
+import com.ifochka.m14n.ui.artistdetails.ArtistDetailsUiState.Success
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ArtistDetailsViewModel(
+    private val api: M14nApi,
+    private val artworkRepository: ArtworkRepository,
+    private val artistId: Long,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<ArtistDetailsUiState>(Loading)
+    val uiState: StateFlow<ArtistDetailsUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _uiState.value = api.getArtistInfo(artistId)
+                .fold(
+                    onSuccess = { info ->
+                        val heroUrl = info.tracks?.firstOrNull()
+                            ?.let { artworkRepository.getArtworkUrl(it) }
+                        Success(
+                            artist = info.artist,
+                            globalRank = info.globalRank,
+                            tracks = info.tracks ?: emptyList(),
+                            relations = info.artistRelations ?: emptyList(),
+                            artworkUrl = heroUrl,
+                        )
+                    },
+                    onFailure = { ArtistDetailsUiState.Error(it.message ?: "Unknown error") },
+                )
+        }
+    }
+
+    suspend fun loadArtworkForTrack(track: Track) {
+        val url = artworkRepository.getArtworkUrl(track) ?: return
+        _uiState.update { state ->
+            if (state !is Success) return@update state
+            state.copy(
+                tracks = state.tracks.map { t ->
+                    if (t.id == track.id) t.copy(artworkUrl = url) else t
+                },
+            )
+        }
+    }
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/search/SearchScreen.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/search/SearchScreen.kt
@@ -32,6 +32,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun SearchScreen(
     onTrackClick: (Long) -> Unit = {},
+    onArtistClick: (Long) -> Unit = {},
     viewModel: SearchViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -107,7 +108,10 @@ fun SearchScreen(
                         FlowRow(modifier = Modifier.padding(horizontal = 16.dp)) {
                             state.artists.forEach { artist ->
                                 SuggestionChip(
-                                    onClick = { viewModel.setQuery(artist.name ?: "") },
+                                    onClick = {
+                                        artist.id?.let(onArtistClick)
+                                            ?: viewModel.setQuery(artist.name ?: "")
+                                    },
                                     label = { Text(artist.name ?: "") },
                                     modifier = Modifier.padding(end = 8.dp),
                                 )

--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/trackdetails/TrackDetailsScreen.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/trackdetails/TrackDetailsScreen.kt
@@ -1,6 +1,7 @@
 package com.ifochka.m14n.ui.trackdetails
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,6 +54,7 @@ import com.ifochka.m14n.data.model.Track
 fun TrackDetailsScreen(
     viewModel: TrackDetailsViewModel,
     onBack: () -> Unit,
+    onArtistClick: (Long) -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val title = (uiState as? TrackDetailsUiState.Success)?.track?.title ?: ""
@@ -83,6 +85,7 @@ fun TrackDetailsScreen(
                     track = state.track,
                     history = state.history,
                     globalRank = state.globalRank,
+                    onArtistClick = onArtistClick,
                     modifier = Modifier.padding(padding),
                 )
             }
@@ -100,6 +103,7 @@ private fun TrackDetailsContent(
     track: Track,
     history: Map<String, Map<String, Int>>?,
     globalRank: Long,
+    onArtistClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.verticalScroll(rememberScrollState())) {
@@ -174,6 +178,7 @@ private fun TrackDetailsContent(
                 MetadataRow(
                     label = "Artist",
                     value = track.artist?.name ?: track.artistName ?: "—",
+                    onValueClick = track.artist?.id?.let { id -> { onArtistClick(id) } },
                 )
             }
         }
@@ -247,6 +252,7 @@ private fun MetadataRow(
     label: String,
     value: String,
     trailingIcon: @Composable (() -> Unit)? = null,
+    onValueClick: (() -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
@@ -262,10 +268,19 @@ private fun MetadataRow(
             trailingIcon()
             Spacer(modifier = Modifier.width(4.dp))
         }
+        val valueModifier = if (onValueClick != null) Modifier.clickable(onClick = onValueClick) else Modifier
         Text(
             text = value,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
+            color = if (onValueClick !=
+                null
+            ) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            modifier = valueModifier,
         )
     }
 }


### PR DESCRIPTION
## Summary

- New `ArtistDetailsScreen` with 16:9 `ArtworkHero`, top 5 tracks list, and collaborator chips
- `ArtistInfo` model + `getArtistInfo` API endpoint (`/artist/info`)
- `RouteArtistDetails` navigation route with full back-stack support (Artist A → B → back)
- From **TrackDetails**: artist name is now primary-colored and tappable → opens `ArtistDetailsScreen`
- From **Search**: artist chips navigate to `ArtistDetailsScreen` instead of filling the search bar
- Wide screen: artist details appear in the right detail pane (existing `ListDetail` scene strategy)

## Test plan

- [ ] Search "Bad Bunny" → tap artist chip → `ArtistDetailsScreen` opens with name + global rank
- [ ] Hero shows 16:9 artwork loaded from first track (or `MusicNote` icon fallback)
- [ ] Top Tracks: tap a row → `TrackDetailsScreen` opens
- [ ] Collaborators: tap a chip → another `ArtistDetailsScreen` pushed; Back returns to previous artist
- [ ] From `TrackDetails`, tap artist name (primary color) → `ArtistDetailsScreen`
- [ ] Wide screen (≥840dp): artist details appear in right pane; list pane stays in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)