### PR TITLE
Fix: Track of the Day now passes current date to API

### DIFF
--- a/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/home/HomeViewModel.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/ifochka/m14n/ui/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.ifochka.m14n.data.api.M14nApi
 import com.ifochka.m14n.data.artwork.ArtworkRepository
 import com.ifochka.m14n.data.model.Track
+import com.ifochka.m14n.data.util.DateUtils
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,7 +32,7 @@ class HomeViewModel(
         loadJob = viewModelScope.launch {
             _uiState.value = HomeUiState.Loading
 
-            val dayTrackDeferred = async { api.getDayTrack() }
+            val dayTrackDeferred = async { api.getDayTrack(date = DateUtils.getTodayAsString()) }
             val trendsDeferred = async { api.getTrends() }
 
             val dayTrackResult = dayTrackDeferred.await()


### PR DESCRIPTION
## Summary

- `HomeViewModel.load()` was calling `api.getDayTrack()` with no arguments
- The backend fell back to `findLast()` — returning the same most-recent DB record every day
- Fix: pass `DateUtils.getTodayAsString()` so the backend calls `findByDay(date)` and returns the correct track for each calendar day

## Test plan

- [ ] Open the Home screen — Track of the Day should reflect today's date
- [ ] Verify the request includes `?date=yyyy-MM-dd` in network logs
- [ ] Confirm different dates return different tracks (if DB has records for multiple days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)