### PR TITLE
CI: inject APPLE_MUSIC_TOKEN into web build workflow

### DIFF
--- a/.github/workflows/template-web-build-and-deploy.yml
+++ b/.github/workflows/template-web-build-and-deploy.yml
@@ -18,6 +18,8 @@ on:
         required: true
       FB_WEB_API_KEY:
         required: true
+      APPLE_MUSIC_TOKEN:
+        required: true
 
 jobs:
   deploy:
@@ -40,7 +42,11 @@ jobs:
           cache-read-only: false
 
       - name: Build WASM distribution
-        run: ./gradlew :frontend:composeApp:wasmJsBrowserDistribution -PVERSION_NAME=${{ inputs.version }} -PFIREBASE_API_KEY=${{ secrets.FB_WEB_API_KEY }}
+        run: |
+          ./gradlew :frontend:composeApp:wasmJsBrowserDistribution \
+            -PVERSION_NAME=${{ inputs.version }} \
+            -PFIREBASE_API_KEY=${{ secrets.FB_WEB_API_KEY }} \
+            -PAPPLE_MUSIC_TOKEN=${{ secrets.APPLE_MUSIC_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary

- Declares `APPLE_MUSIC_TOKEN` as a required secret in `template-web-build-and-deploy.yml`
- Passes it as `-PAPPLE_MUSIC_TOKEN` to the Gradle build step
- Reformats all Gradle `-P` flags onto separate lines with `\` for readability
- No changes needed in `deploy-web-test.yml` — it already uses `secrets: inherit`

## Test plan

- [ ] Add `APPLE_MUSIC_TOKEN` secret in GitHub → Settings → Secrets and variables → Actions
- [ ] Trigger a web deploy — build should receive the token and bake it into `BuildKonfig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)