### PR TITLE
Fix: revert Apple redirectURI to Firebase auth handler URL

### DIFF
--- a/frontend/composeApp/src/wasmJsMain/resources/firebase-bridge.js
+++ b/frontend/composeApp/src/wasmJsMain/resources/firebase-bridge.js
@@ -67,7 +67,7 @@ async function jsSignInWithApplePopup(serviceId, apiBaseUrl) {
     AppleID.auth.init({
         clientId: serviceId,
         scope: 'name email',
-        redirectURI: 'https://api.m14n.com/auth/apple/callback',
+        redirectURI: 'https://m14n-41a5a.firebaseapp.com/__/auth/handler',
         nonce: hashedNonce,
         usePopup: true,
     });


### PR DESCRIPTION
## Summary
- Reverts `redirectURI` in `jsSignInWithApplePopup` back to `https://m14n-41a5a.firebaseapp.com/__/auth/handler`
- Previous change to `https://api.m14n.com/auth/apple/callback` caused `invalid_client` from Apple
- Firebase auth handler URL is the registered Return URL for Service ID `com.ifochka.m14n.sid`

## Test plan
- [ ] Open test.m14n.com → tap "Continue with Apple" → popup opens without `invalid_client` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)