### PR TITLE
Fix: explicitly init Firebase in Android before Koin starts

### DIFF
--- a/frontend/androidApp/src/main/java/com/ifochka/m14n/app/M14nApplication.kt
+++ b/frontend/androidApp/src/main/java/com/ifochka/m14n/app/M14nApplication.kt
@@ -6,12 +6,15 @@ import android.app.NotificationManager
 import android.os.Build
 import com.google.firebase.messaging.FirebaseMessaging
 import com.ifochka.m14n.di.appModule
+import com.ifochka.m14n.initAndroidFirebase
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
 class M14nApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        initAndroidFirebase()
 
         startKoin {
             androidContext(this@M14nApplication)

--- a/frontend/composeApp/src/androidMain/kotlin/com/ifochka/m14n/AndroidFirebaseInit.kt
+++ b/frontend/composeApp/src/androidMain/kotlin/com/ifochka/m14n/AndroidFirebaseInit.kt
@@ -1,0 +1,17 @@
+package com.ifochka.m14n
+
+import com.ifochka.auth.FirebaseAuthConfig
+import com.ifochka.auth.initFirebase
+
+fun initAndroidFirebase() {
+    initFirebase(
+        FirebaseAuthConfig(
+            apiKey = BuildKonfig.FIREBASE_API_KEY,
+            projectId = BuildKonfig.FIREBASE_PROJECT_ID,
+            appId = BuildKonfig.FIREBASE_APP_ID,
+            authDomain = BuildKonfig.FIREBASE_AUTH_DOMAIN,
+            googleWebClientId = BuildKonfig.GOOGLE_WEB_CLIENT_ID,
+            useEmulator = BuildKonfig.USE_FIREBASE_EMULATOR,
+        ),
+    )
+}


### PR DESCRIPTION
## Summary
- Adds `initAndroidFirebase()` call in `M14nApplication.onCreate()` before `startKoin`
- Extracts `AndroidFirebaseInit.kt` helper in `androidMain` that passes all required `FirebaseAuthConfig` fields from `BuildKonfig`

**Root cause:** `AuthRepository` is created eagerly at Koin start (`createdAtStart = true`). Its `init` block accesses `Firebase.auth`, which requires `AuthConfig.current` to be set first. The explicit `initAndroidFirebase()` call ensures this happens before Koin starts.

## Test plan
- [ ] Build and run Android app
- [ ] Verify no `Default FirebaseApp is not initialized` crash on startup
- [ ] Verify sign-in flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)