### PR TITLE
Fix: default empty allowlist to prevent startup crash when PLAY_INTEGRITY_ALLOWED_PACKAGES is unset

### DIFF
--- a/backend/src/main/resources/application-production.properties
+++ b/backend/src/main/resources/application-production.properties
@@ -52,4 +52,4 @@ firebase.project-id=${FIREBASE_PROJECT_ID}
 firebase.web-api-key=${FB_WEB_API_KEY}
 
 # Play Integrity API — comma-separated list of allowed Android package names
-play.integrity.allowed-packages=${PLAY_INTEGRITY_ALLOWED_PACKAGES}
+play.integrity.allowed-packages=${PLAY_INTEGRITY_ALLOWED_PACKAGES:}


### PR DESCRIPTION
## Summary

- Adds `:` default to `${PLAY_INTEGRITY_ALLOWED_PACKAGES}` in `application-production.properties` so the app starts cleanly when the env var is not set
- Without this, Spring fails to resolve the placeholder at startup and crashes before serving any traffic

## Test plan

- [ ] Deploy without `PLAY_INTEGRITY_ALLOWED_PACKAGES` set — app should start normally
- [ ] All integrity requests return `pass: false` when allowlist is empty (expected behaviour)
- [ ] Set `PLAY_INTEGRITY_ALLOWED_PACKAGES=com.ifochka.jufk` — requests from that package name work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)